### PR TITLE
New libraries: TCA9544A and AD5243

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1324,6 +1324,8 @@ https://github.com/dojyorin/arduino_base64
 https://github.com/dojyorin/arduino_percent
 https://github.com/dok-net/CoopTask
 https://github.com/dok-net/esp_sds011
+https://github.com/dok-net/ad5243.git
+https://github.com/dok-net/tca9544a.git
 https://github.com/DonnyCraft1/PIDArduino
 https://github.com/douglaslyon/AudioShieldDTMF
 https://github.com/dparson55/NRFLite


### PR DESCRIPTION
The TCA9544A family of digital potentiometers and rheostats are supported by the new library.
The AD5243 I2C multiplexer is supported by the new library.
Currently only tested on Espressif's ESP8266 and ESP32 MCUs, if someone posts an issue to the project site requesting support for further (Arduino) MCUs, and supplies testimony that they have successfully used the software on them, I will happily extend the libraries' manifests.